### PR TITLE
Do not reuse facet_fields array when generating facet results

### DIFF
--- a/search_service/search/views.py
+++ b/search_service/search/views.py
@@ -858,16 +858,15 @@ class IIIFSearch(viewsets.ModelViewSet, ListModelMixin):
         if not facet_types:
             facet_types = ["metadata"]
         for facet_type in facet_types:
-            if not facet_fields:
-                facet_fields = []
-                facet_field_labels = (
-                    facetable_q.filter(indexables__type__iexact=facet_type)
-                    .values("indexables__subtype")
-                    .distinct()
-                )
-                for t in facet_field_labels:
-                    for _, v in t.items():
-                        facet_fields.append(v)
+            facet_fields = []
+            facet_field_labels = (
+                facetable_q.filter(indexables__type__iexact=facet_type)
+                .values("indexables__subtype")
+                .distinct()
+            )
+            for t in facet_field_labels:
+                for _, v in t.items():
+                    facet_fields.append(v)
             for v in facet_fields:
                 facet_summary[facet_type][v] = {
                     x["indexables__indexable"]: x["n"]


### PR DESCRIPTION
The inclusion of `if not facet_fields:` inside the loop meant that only the first facet_type would have results rendered. Subsequent facet_types would have the same fields repeated but they would be empty.

This would then result in the following output

```json
{
    "facet_types": [
        "property",
        "concept",
        "activity"
    ]
}
```

we would get

```json
"facets": {
    "property": {
        "dateText": {
            "13/11/08": 1
        },
        "endDate": {
            "2008-11-13 00:00:00": 1
        },
        "startDate": {
            "2008-11-13 00:00:00": 1
        }
    },
    "concept": {
        "dateText": {},
        "endDate": {},
        "startDate": {}
    },
    "activity": {
        "dateText": {},
        "endDate": {},
        "startDate": {}
    }
}
```