### PR TITLE
Allow page_size to be controlled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # Custom
 var/shared-database
+
+.idea/

--- a/API.md
+++ b/API.md
@@ -607,3 +607,14 @@ N.B. The following fields are compulsory:
 * subtype: e.g. custom_subfield
 
 N.B. the _resource_id_ __must__ exist and must be already in the search service.
+
+## Pagination
+
+API endpoints supports pagination. This can be controlled at query time, using the following query parameters (supported in both GET and POST operations)
+
+* `?page=2`: return the second page of results.
+* `?page_size=10`: limit the number of results to `10` items.
+
+Default page_size is controlled by the `PAGE_SIZE` environment variable, defaulted to 25.
+
+The `MAX_PAGE_SIZE` environment variable can be used to set a limit on how many results to allow. By default this is _not_ set, allowing any page_size to be set.

--- a/search_service/search/views.py
+++ b/search_service/search/views.py
@@ -310,11 +310,15 @@ class MadocPagination(PageNumberPagination):
       }
     """
 
+    page_size_query_param = "page_size"
+    max_page_size = settings.MAX_PAGE_SIZE
+
     def get_paginated_response(self, data):
         return Response(
             {
                 "pagination": {
                     "page": self.page.number,
+                    "pageSize": self.page.paginator.per_page,
                     "totalPages": self.page.paginator.num_pages,
                     "totalResults": self.page.paginator.count,
                 },

--- a/search_service/search_service/settings.py
+++ b/search_service/search_service/settings.py
@@ -93,11 +93,12 @@ WSGI_APPLICATION = "search_service.wsgi.application"
 
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    "PAGE_SIZE": 25,
+    "PAGE_SIZE": env.int("PAGE_SIZE", 25)
 }
 
-BROWSABLE = strtobool(env("BROWSABLE", default="False"))
+MAX_PAGE_SIZE = env.int("MAX_PAGE_SIZE", None)
 
+BROWSABLE = strtobool(env("BROWSABLE", default="False"))
 
 if not BROWSABLE:
     REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ("rest_framework.renderers.JSONRenderer",)


### PR DESCRIPTION
Use `PAGE_SIZE` env_var for default and `?page_size` query param.

Allow optional `MAX_PAGE_SIZE` to limit return set.