### PR TITLE
Handle multiple error types in parenthesised tuple

### DIFF
--- a/search_service/search/serializers.py
+++ b/search_service/search/serializers.py
@@ -186,7 +186,7 @@ class IIIFSearchSummarySerializer(serializers.HyperlinkedModelSerializer):
         """
         try:
             return max([h["rank"] for h in self.get_hits(iiif=iiif)])
-        except TypeError or ValueError:
+        except (TypeError, ValueError):
             return 1.0
 
     def get_hits(self, iiif):


### PR DESCRIPTION
Was still getting a `ValueError` when using `or` syntax, updating to named tuple resolved.