### PR TITLE
Allow default PAGE_SIZE to be set by envvar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # Custom
 var/shared-database
+
+.idea/

--- a/search_service/search_service/settings.py
+++ b/search_service/search_service/settings.py
@@ -99,7 +99,7 @@ WSGI_APPLICATION = "search_service.wsgi.application"
 
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "search.pagination.MadocPagination",
-    "PAGE_SIZE": 25,
+    "PAGE_SIZE": env.int("PAGE_SIZE", 25),
 }
 
 MAX_PAGE_SIZE = env.int("MAX_PAGE_SIZE", None)


### PR DESCRIPTION
Last piece of functionality that was in UAL branch. Copied from https://github.com/digirati-co-uk/madoc_search_proto/commit/4b05b606f42a1d35cd2fce03e6c99139d6257e45 and tested locally.